### PR TITLE
Some code changes

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -78,5 +78,8 @@
     ],
     "U2MQ894Z4M.br.com.cinemark.iphone": [
         "cinemark.com.br"
+    ],
+    "2V2KHYTNSF.com.keybank.mobile": [
+        "key.com"
     ]
 }

--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -75,5 +75,8 @@
     "498RNR3HN7.com.tdbank.iphoneapp": [
         "td.com",
         "tdbank.com"
+    ],
+    "U2MQ894Z4M.br.com.cinemark.iphone": [
+        "cinemark.com.br"
     ]
 }

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -110,6 +110,7 @@
     "chess.com": "https://www.chess.com/settings/password",
     "chewy.com": "https://www.chewy.com/app/resetpassword",
     "churchofjesuschrist.org": "https://account.churchofjesuschrist.org/changePassword",
+    "cinemark.com.br": "https://www.cinemark.com.br/minha-conta",
     "citi.com": "https://online.citi.com/US/ag/profile-update/change-password",
     "claro.com.br": "https://minhanet.net.com.br/webcenter/portal/MinhaNet/pages_alterarsenha",
     "clevelandclinic.org": "https://mychart.clevelandclinic.org/inside.asp?mode=passwd",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -245,6 +245,7 @@
     "leetcode.com": "https://leetcode.com/accounts/password/set/",
     "legacy.com": "https://legacy.memoriams.com/Network/Account/ChangePassword",
     "lemonde.fr": "https://moncompte.lemonde.fr/gcustomer/account/password",
+    "letterboxd.com": "https://letterboxd.com/settings/auth/",
     "linkedin.com": "https://www.linkedin.com/psettings/change-password",
     "linktr.ee": "https://linktr.ee/admin/account",
     "linode.com": "https://cloud.linode.com/profile/auth",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ ] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [ ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [ ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
